### PR TITLE
ENH: implement == on Array and object

### DIFF
--- a/libpy_simdjson/parser.cc
+++ b/libpy_simdjson/parser.cc
@@ -7,6 +7,7 @@
 #include <libpy/autofunction.h>
 #include <libpy/automodule.h>
 #include <libpy/build_tuple.h>
+#include <libpy/itertools.h>
 #include <libpy/to_object.h>
 #include <range/v3/all.hpp>
 
@@ -169,18 +170,28 @@ public:
         return py::to_object(m_value);
     }
 
-    std::size_t size() {
+    std::size_t size() const {
         return m_value.size();
     }
 
     typedef simdjson::dom::array::iterator iterator;
 
-    iterator begin() {
+    iterator begin() const {
         return m_value.begin();
     }
 
-    iterator end() {
+    iterator end() const {
         return m_value.end();
+    }
+
+    bool operator==(const array_element& other) {
+        if (this->size() != other.size()) {
+            return false;
+        }
+
+        auto comp = std::equal(begin(), end(), other.begin());
+
+        return comp;
     }
 };
 
@@ -302,6 +313,7 @@ LIBPY_AUTOMODULE(libpy_simdjson,
         .def<&array_element::at>("at")
         .def<&array_element::as_list>("as_list")
         .mapping<std::ptrdiff_t>()
+        .comparisons<array_element>()
         .len()
         .iter()
         .type();

--- a/libpy_simdjson/parser.cc
+++ b/libpy_simdjson/parser.cc
@@ -115,7 +115,8 @@ bool element_eq(simdjson::dom::object lhs, simdjson::dom::object rhs) {
     return lhs.size() == rhs.size() &&
            std::equal(lhs.begin(), lhs.end(), rhs.begin(), [](auto a, auto b) {
                return a.key == b.key && as_static_type(a.value, [&](auto a_static) {
-                          if constexpr (std::is_same_v<decltype(a_static), std::nullptr_t>) {
+                          if constexpr (std::is_same_v<decltype(a_static),
+                                                       std::nullptr_t>) {
                               return b.value.type() ==
                                      simdjson::dom::element_type::NULL_VALUE;
                           }

--- a/libpy_simdjson/simdjson.h
+++ b/libpy_simdjson/simdjson.h
@@ -1,4 +1,4 @@
-/* auto-generated on Fri Jul 17 14:52:28 EDT 2020. Do not edit! */
+/* auto-generated on Tue 21 Jul 2020 17:54:23 EDT. Do not edit! */
 /* begin file include/simdjson.h */
 #ifndef SIMDJSON_H
 #define SIMDJSON_H
@@ -67,7 +67,7 @@
  * We want to differentiate carefully between
  * clang under visual studio and regular visual
  * studio.
- *
+ * 
  * Under clang for Windows, we enable:
  *  * target pragmas so that part and only part of the
  *     code gets compiled for advanced instructions.
@@ -94,7 +94,7 @@
 #define SIMDJSON_IS_X86_64 1
 #elif defined(__aarch64__) || defined(_M_ARM64)
 #define SIMDJSON_IS_ARM64 1
-#else
+#else 
 #define SIMDJSON_IS_32BITS 1
 
 // We do not support 32-bit platforms, but it can be
@@ -135,12 +135,12 @@ use a 64-bit target such as x64 or 64-bit ARM.")
 
 // Our fast kernels require 64-bit systems.
 //
-// On 32-bit x86, we lack 64-bit popcnt, lzcnt, blsr instructions.
-// Furthermore, the number of SIMD registers is reduced.
+// On 32-bit x86, we lack 64-bit popcnt, lzcnt, blsr instructions. 
+// Furthermore, the number of SIMD registers is reduced. 
 //
 // On 32-bit ARM, we would have smaller registers.
 //
-// The simdjson users should still have the fallback kernel. It is
+// The simdjson users should still have the fallback kernel. It is 
 // slower, but it should run everywhere.
 #if SIMDJSON_IS_X86_64
 #ifndef SIMDJSON_IMPLEMENTATION_HASWELL
@@ -373,7 +373,7 @@ constexpr size_t DEFAULT_MAX_DEPTH = 1024;
   #define SIMDJSON_DISABLE_VS_WARNING(WARNING_NUMBER) __pragma(warning( disable : WARNING_NUMBER ))
   // Get rid of Intellisense-only warnings (Code Analysis)
   // Though __has_include is C++17, it is supported in Visual Studio 2017 or better (_MSC_VER>=1910).
-  #if defined(_MSC_VER) && (_MSC_VER>=1910)
+  #if defined(_MSC_VER) && (_MSC_VER>=1910) 
   #if __has_include(<CppCoreCheck\Warnings.h>)
   #include <CppCoreCheck\Warnings.h>
   #define SIMDJSON_DISABLE_UNDESIRED_WARNINGS SIMDJSON_DISABLE_VS_WARNING(ALL_CPPCORECHECK_WARNINGS)
@@ -389,8 +389,8 @@ constexpr size_t DEFAULT_MAX_DEPTH = 1024;
 
 #else // SIMDJSON_REGULAR_VISUAL_STUDIO
 
-  #define really_inline inline __attribute__((always_inline, unused))
-  #define never_inline inline __attribute__((noinline, unused))
+  #define really_inline inline __attribute__((always_inline))
+  #define never_inline inline __attribute__((noinline))
 
   #define UNUSED __attribute__((unused))
   #define WARN_UNUSED __attribute__((warn_unused_result))
@@ -2040,7 +2040,7 @@ SIMDJSON_DISABLE_UNDESIRED_WARNINGS
 #define SIMDJSON_SIMDJSON_VERSION_H
 
 /** The version of simdjson being used (major.minor.revision) */
-#define SIMDJSON_VERSION 0.4.7
+#define SIMDJSON_VERSION 0.4.6
 
 namespace simdjson {
 enum {
@@ -2055,7 +2055,7 @@ enum {
   /**
    * The revision (major.minor.REVISION) of simdjson being used.
    */
-  SIMDJSON_VERSION_REVISION = 7
+  SIMDJSON_VERSION_REVISION = 6
 };
 } // namespace simdjson
 
@@ -2500,7 +2500,7 @@ public:
    * @private For internal implementation use
    *
    * Run a full JSON parse on a single document (stage1 + stage2).
-   *
+   * 
    * Guaranteed only to be called when capacity > document length.
    *
    * Overridden by each implementation.
@@ -2515,7 +2515,7 @@ public:
    * @private For internal implementation use
    *
    * Stage 1 of the document parser.
-   *
+   * 
    * Guaranteed only to be called when capacity > document length.
    *
    * Overridden by each implementation.
@@ -2531,7 +2531,7 @@ public:
    * @private For internal implementation use
    *
    * Stage 2 of the document parser.
-   *
+   * 
    * Called after stage1().
    *
    * Overridden by each implementation.
@@ -2556,7 +2556,7 @@ public:
 
   /**
    * Change the capacity of this parser.
-   *
+   * 
    * Generally used for reallocation.
    *
    * @param capacity The new capacity.
@@ -2763,9 +2763,9 @@ public:
    * @return the error code, or SUCCESS if there was no error.
    */
   WARN_UNUSED virtual error_code minify(const uint8_t *buf, size_t len, uint8_t *dst, size_t &dst_len) const noexcept = 0;
-
-
-  /**
+  
+  
+  /**   
    * Validate the UTF-8 string.
    *
    * Overridden by each implementation.
@@ -3073,10 +3073,13 @@ public:
 
   class iterator {
   public:
+    using value_type = element;
+    using difference_type = std::ptrdiff_t;
+
     /**
      * Get the actual value
      */
-    inline element operator*() const noexcept;
+    inline value_type operator*() const noexcept;
     /**
      * Get the next value.
      *
@@ -3085,11 +3088,27 @@ public:
      */
     inline iterator& operator++() noexcept;
     /**
+     * Get the next value.
+     *
+     * Part of the  std::iterator interface.
+     */
+    inline iterator operator++(int) noexcept;
+    /**
      * Check if these values come from the same place in the JSON.
      *
      * Part of the std::iterator interface.
      */
     inline bool operator!=(const iterator& other) const noexcept;
+    inline bool operator==(const iterator& other) const noexcept;
+
+    inline bool operator<(const iterator& other) const noexcept;
+    inline bool operator<=(const iterator& other) const noexcept;
+    inline bool operator>=(const iterator& other) const noexcept;
+    inline bool operator>(const iterator& other) const noexcept;
+
+    iterator() noexcept = default;
+    iterator(const iterator&) noexcept = default;
+    iterator& operator=(const iterator&) noexcept = default;
   private:
     really_inline iterator(const internal::tape_ref &tape) noexcept;
     internal::tape_ref tape;
@@ -3133,7 +3152,7 @@ public:
   /**
    * Get the value at the given index. This function has linear-time complexity and
    * is equivalent to the following:
-   *
+   * 
    *    size_t i=0;
    *    for (auto element : *this) {
    *      if (i == index) { return element; }
@@ -3142,7 +3161,7 @@ public:
    *    return INDEX_OUT_OF_BOUNDS;
    *
    * Avoid calling the at() function repeatedly.
-   *
+   * 
    * @return The value at the given index, or:
    *         - INDEX_OUT_OF_BOUNDS if the array index is larger than an array length
    */
@@ -3204,6 +3223,20 @@ inline std::ostream& operator<<(std::ostream& out, const simdjson_result<dom::ar
 #endif
 
 } // namespace simdjson
+
+
+#if defined(__cpp_lib_ranges)
+#include <ranges>
+
+namespace std::ranges {
+template<>
+inline constexpr bool enable_view<simdjson::dom::array> = true;
+}
+
+static_assert(std::ranges::view<simdjson::dom::array>);
+static_assert(std::ranges::sized_range<simdjson::dom::array>);
+#endif
+
 
 #endif // SIMDJSON_DOM_ARRAY_H
 /* end file include/simdjson/minify.h */
@@ -3443,7 +3476,7 @@ public:
    * documents that consist of an object or array may omit the whitespace between them, concatenating
    * with no separator. documents that consist of a single primitive (i.e. documents that are not
    * arrays or objects) MUST be separated with whitespace.
-   *
+   * 
    * The documents must not exceed batch_size bytes (by default 1MB) or they will fail to parse.
    * Setting batch_size to excessively large or excesively small values may impact negatively the
    * performance.
@@ -3476,11 +3509,11 @@ public:
    * If the parser's current capacity is less than batch_size, it will allocate enough capacity
    * to handle it (up to max_capacity).
    *
-   * @param path File name pointing at the concatenated JSON to parse.
+   * @param path File name pointing at the concatenated JSON to parse. 
    * @param batch_size The batch size to use. MUST be larger than the largest document. The sweet
    *                   spot is cache-related: small enough to fit in cache, yet big enough to
    *                   parse as many documents as possible in one tight loop.
-   *                   Defaults to 10MB, which has been a reasonable sweet spot in our tests.
+   *                   Defaults to 1MB (as simdjson::dom::DEFAULT_BATCH_SIZE), which has been a reasonable sweet spot in our tests.
    * @return The stream, or an error. An empty input will yield 0 documents rather than an EMPTY error. Errors:
    *         - IO_ERROR if there was an error opening or reading the file.
    *         - MEMALLOC if the parser does not have enough capacity and memory allocation fails.
@@ -3507,7 +3540,7 @@ public:
    * documents that consist of an object or array may omit the whitespace between them, concatenating
    * with no separator. documents that consist of a single primitive (i.e. documents that are not
    * arrays or objects) MUST be separated with whitespace.
-   *
+   * 
    * The documents must not exceed batch_size bytes (by default 1MB) or they will fail to parse.
    * Setting batch_size to excessively large or excesively small values may impact negatively the
    * performance.
@@ -3735,13 +3768,13 @@ struct stage1_worker {
   stage1_worker(stage1_worker&&) = delete;
   stage1_worker operator=(const stage1_worker&) = delete;
   ~stage1_worker();
-  /**
+  /** 
    * We only start the thread when it is needed, not at object construction, this may throw.
-   * You should only call this once.
+   * You should only call this once. 
    **/
   void start_thread();
-  /**
-   * Start a stage 1 job. You should first call 'run', then 'finish'.
+  /** 
+   * Start a stage 1 job. You should first call 'run', then 'finish'. 
    * You must call start_thread once before.
    */
   void run(document_stream * ds, dom::parser * stage1, size_t next_batch_start);
@@ -3750,10 +3783,10 @@ struct stage1_worker {
 
 private:
 
-  /**
+  /** 
    * Normally, we would never stop the thread. But we do in the destructor.
-   * This function is only safe assuming that you are not waiting for results. You
-   * should have called run, then finish, and be done.
+   * This function is only safe assuming that you are not waiting for results. You 
+   * should have called run, then finish, and be done. 
    **/
   void stop_thread();
 
@@ -3762,8 +3795,8 @@ private:
   dom::parser * stage1_thread_parser{};
   size_t _next_batch_start{};
   document_stream * owner{};
-  /**
-   * We have two state variables. This could be streamlined to one variable in the future but
+  /** 
+   * We have two state variables. This could be streamlined to one variable in the future but 
    * we use two for clarity.
    */
   bool has_work{false};
@@ -3821,7 +3854,7 @@ public:
     really_inline bool operator!=(const iterator &other) const noexcept;
     /**
      * @private
-     *
+     * 
      * Gives the current index in the input document in bytes.
      *
      *   document_stream stream = parser.parse_many(json,window);
@@ -3829,10 +3862,10 @@ public:
      *      auto doc = *i;
      *      size_t index = i.current_index();
      *   }
-     *
+     * 
      * This function (current_index()) is experimental and the usage
      * may change in future versions of simdjson: we find the API somewhat
-     * awkward and we would like to offer something friendlier.
+     * awkward and we would like to offer something friendlier.  
      */
      really_inline size_t current_index() noexcept;
   private:
@@ -4034,14 +4067,14 @@ public:
    */
   inline simdjson_result<object> get_object() const noexcept;
   /**
-   * Cast this element to a null-terminated C string.
-   *
+   * Cast this element to a null-terminated C string. 
+   * 
    * The string is guaranteed to be valid UTF-8.
    *
    * The get_c_str() function is equivalent to get<const char *>().
-   *
+   * 
    * The length of the string is given by get_string_length(). Because JSON strings
-   * may contain null characters, it may be incorrect to use strlen to determine the
+   * may contain null characters, it may be incorrect to use strlen to determine the 
    * string length.
    *
    * It is possible to get a single string_view instance which represents both the string
@@ -4054,7 +4087,7 @@ public:
   inline simdjson_result<const char *> get_c_str() const noexcept;
   /**
    * Gives the length in bytes of the string.
-   *
+   * 
    * It is possible to get a single string_view instance which represents both the string
    * content and its length: see get_string().
    *
@@ -4063,8 +4096,8 @@ public:
    */
   inline simdjson_result<size_t> get_string_length() const noexcept;
   /**
-   * Cast this element to a string.
-   *
+   * Cast this element to a string. 
+   * 
    * The string is guaranteed to be valid UTF-8.
    *
    * Equivalent to get<std::string_view>().
@@ -4247,7 +4280,7 @@ public:
 
   /**
    * Read this element as a null-terminated UTF-8 string.
-   *
+   * 
    * Be mindful that JSON allows strings to contain null characters.
    *
    * Does *not* convert other types to a string; requires that the JSON type of the element was
@@ -4540,6 +4573,7 @@ public:
   class iterator {
   public:
     using value_type = key_value_pair;
+    using difference_type = std::ptrdiff_t;
 
     /**
      * Get the actual key/value pair
@@ -4552,20 +4586,25 @@ public:
      *
      */
     inline iterator& operator++() noexcept;
-    inline iterator operator++(int) noexcept {
-        iterator out = *this;
-        ++*this;
-        return out;
-    }
     /**
-     * Check if these key value pairs come from the same place in the JSON.
+     * Get the next key/value pair.
+     *
+     * Part of the std::iterator interface.
+     *
+     */
+    inline iterator operator++(int) noexcept;
+    /**
+     * Check if these values come from the same place in the JSON.
      *
      * Part of the std::iterator interface.
      */
     inline bool operator!=(const iterator& other) const noexcept;
-    inline bool operator==(const iterator& other) const noexcept {
-        return !(*this != other);
-    }
+    inline bool operator==(const iterator& other) const noexcept;
+
+    inline bool operator<(const iterator& other) const noexcept;
+    inline bool operator<=(const iterator& other) const noexcept;
+    inline bool operator>=(const iterator& other) const noexcept;
+    inline bool operator>(const iterator& other) const noexcept;
     /**
      * Get the key of this key/value pair.
      */
@@ -4595,12 +4634,9 @@ public:
      */
     inline element value() const noexcept;
 
-    inline iterator(const iterator& other) = default;
-    inline iterator& operator=(const iterator& other) = default;
-    inline iterator() = default;
-
-    using difference_type = std::ptrdiff_t;
-
+    iterator() noexcept = default;
+    iterator(const iterator&) noexcept = default;
+    iterator& operator=(const iterator&) noexcept = default;
   private:
     really_inline iterator(const internal::tape_ref &tape) noexcept;
 
@@ -4792,6 +4828,20 @@ inline std::ostream& operator<<(std::ostream& out, const simdjson_result<dom::ob
 #endif // SIMDJSON_EXCEPTIONS
 
 } // namespace simdjson
+
+
+#if defined(__cpp_lib_ranges)
+#include <ranges>
+
+namespace std::ranges {
+template<>
+inline constexpr bool enable_view<simdjson::dom::object> = true;
+}
+
+static_assert(std::ranges::view<simdjson::dom::object>);
+static_assert(std::ranges::sized_range<simdjson::dom::object>);
+#endif
+
 
 #endif // SIMDJSON_DOM_OBJECT_H
 /* end file include/simdjson/dom/object.h */
@@ -5396,14 +5446,33 @@ really_inline array::iterator::iterator(const internal::tape_ref &_tape) noexcep
 inline element array::iterator::operator*() const noexcept {
   return element(tape);
 }
-inline bool array::iterator::operator!=(const array::iterator& other) const noexcept {
-  return tape.json_index != other.tape.json_index;
-}
 inline array::iterator& array::iterator::operator++() noexcept {
   tape.json_index = tape.after_element();
   return *this;
 }
-
+inline array::iterator array::iterator::operator++(int) noexcept {
+  array::iterator out = *this;
+  ++*this;
+  return out;
+}
+inline bool array::iterator::operator!=(const array::iterator& other) const noexcept {
+  return tape.json_index != other.tape.json_index;
+}
+inline bool array::iterator::operator==(const array::iterator& other) const noexcept {
+  return tape.json_index == other.tape.json_index;
+}
+inline bool array::iterator::operator<(const array::iterator& other) const noexcept {
+  return tape.json_index < other.tape.json_index;
+}
+inline bool array::iterator::operator<=(const array::iterator& other) const noexcept {
+  return tape.json_index <= other.tape.json_index;
+}
+inline bool array::iterator::operator>=(const array::iterator& other) const noexcept {
+  return tape.json_index >= other.tape.json_index;
+}
+inline bool array::iterator::operator>(const array::iterator& other) const noexcept {
+  return tape.json_index > other.tape.json_index;
+}
 inline std::ostream& operator<<(std::ostream& out, const array &value) {
   return out << minify<array>(value);
 }
@@ -6676,10 +6745,30 @@ inline const key_value_pair object::iterator::operator*() const noexcept {
 inline bool object::iterator::operator!=(const object::iterator& other) const noexcept {
   return tape.json_index != other.tape.json_index;
 }
+inline bool object::iterator::operator==(const object::iterator& other) const noexcept {
+  return tape.json_index == other.tape.json_index;
+}
+inline bool object::iterator::operator<(const object::iterator& other) const noexcept {
+  return tape.json_index < other.tape.json_index;
+}
+inline bool object::iterator::operator<=(const object::iterator& other) const noexcept {
+  return tape.json_index <= other.tape.json_index;
+}
+inline bool object::iterator::operator>=(const object::iterator& other) const noexcept {
+  return tape.json_index >= other.tape.json_index;
+}
+inline bool object::iterator::operator>(const object::iterator& other) const noexcept {
+  return tape.json_index > other.tape.json_index;
+}
 inline object::iterator& object::iterator::operator++() noexcept {
   tape.json_index++;
   tape.json_index = tape.after_element();
   return *this;
+}
+inline object::iterator object::iterator::operator++(int) noexcept {
+  object::iterator out = *this;
+  ++*this;
+  return out;
 }
 inline std::string_view object::iterator::key() const noexcept {
   return tape.get_string_view();
@@ -7436,7 +7525,7 @@ really_inline parser::parser(size_t max_capacity) noexcept
   : _max_capacity{max_capacity},
     loaded_bytes(nullptr) {
 }
-#else
+#else 
 really_inline parser::parser(size_t max_capacity) noexcept
   : _max_capacity{max_capacity},
     loaded_bytes(nullptr, &aligned_free_char) {

--- a/libpy_simdjson/tests/test_array.py
+++ b/libpy_simdjson/tests/test_array.py
@@ -1,3 +1,11 @@
+from pathlib import Path
+
+import libpy_simdjson as simdjson
+
+
+JSON_FIXTURES_DIR = Path(__file__).parent / "jsonexamples"
+
+
 def test_as_list(array_element, py_array_element):
     actual_list = array_element.as_list()
     assert actual_list == py_array_element
@@ -18,3 +26,11 @@ def test_indexing(array_element):
 
 def test_at(array_element):
     assert array_element.at(b"5") == 5
+
+
+def test_equality():
+    file_path = JSON_FIXTURES_DIR / "small/smalllist.json"
+    elem_1 = simdjson.load(bytes(file_path))
+    elem_2 = simdjson.load(bytes(file_path))
+
+    assert elem_1 == elem_2

--- a/libpy_simdjson/tests/test_object.py
+++ b/libpy_simdjson/tests/test_object.py
@@ -1,4 +1,9 @@
+from pathlib import Path
+
 import libpy_simdjson as simdjson
+
+
+JSON_FIXTURES_DIR = Path(__file__).parent / "jsonexamples"
 
 
 def test_as_dict(object_element, py_object_element):
@@ -56,3 +61,15 @@ def test_at(object_element):
     assert object_element.at(b"Width") == 800
     assert isinstance(object_element.at(b"array"), simdjson.Array)
     assert object_element.at(b"array/0") == 116
+
+
+def get_new_object_element(object_element):
+    return object_element
+
+
+def test_equality():
+    file_path = JSON_FIXTURES_DIR / "small/smalldemo.json"
+    elem_1 = simdjson.load(bytes(file_path))
+    elem_2 = simdjson.load(bytes(file_path))
+
+    assert elem_1 == elem_2


### PR DESCRIPTION
We can use `as_static_type` as a helper to refactor the work done in https://github.com/gerrymanoim/libpy_simdjson/pull/20 and `disambiguate_result`. 

Closes https://github.com/gerrymanoim/libpy_simdjson/issues/19